### PR TITLE
patch: upgrade how the words transform works

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -49,7 +49,8 @@ function transformValue (pattern, value) {
       value = datetime
       break
     case 'words':
-      value = value.split(/[\s"\.,;-]+/).filter(function (x) { return !!x })
+      value = value.match(/[\w'-]+/ig)
+                   .map(function (x) { return x.toLowerCase() })
       break
   }
   if (pattern.splay || pattern.emit || pattern.flatten) {

--- a/test.js
+++ b/test.js
@@ -232,6 +232,15 @@ function test (dbName) {
             assert.equal(rows.length, 9)
             assert.equal(1, rows.filter(({ key }) => key === 'baby').length)
           })
+          it('should lowercase all indexed values', async function () {
+            const text = 'Hello world!'
+            await this.db.post({ text })
+            await this.db.addJsonView(DDOC_NAME, VIEW_NAME, {
+              map: { key: { access: 'text', transform: 'words', splay: true } }
+            })
+            const { rows } = await this.db.query(`${DDOC_NAME}/${VIEW_NAME}`, { key: 'hello' })
+            assert.equal(rows.length, 1)
+          })
         })
       })
       describe('splay', function () {


### PR DESCRIPTION
Positively match on word-likes rather than the spaces between them. Also lowercase found values, so word-search is effectively case-insensitive.